### PR TITLE
Update ja#sth02.d

### DIFF
--- a/JA#BGT_AdvPack/Shop_of_Silence/ja#sth02.d
+++ b/JA#BGT_AdvPack/Shop_of_Silence/ja#sth02.d
@@ -1,6 +1,6 @@
 BEGIN ~JA#STH02~
 
-IF ~ReputationLT(LastTalkedToBy,FRIENDLY_LOWER)~ THEN JA#STH02_1
+IF ~ReputationLT(LastTalkedToBy,16)~ THEN JA#STH02_1
   SAY @0 = @1
   IF ~~ THEN REPLY @2 GOTO JA#STH02_2
   IF ~Global("JA#KNOW_MASKTEMPLE","GLOBAL",1)~ THEN REPLY @3 GOTO JA#STH02_6
@@ -11,17 +11,17 @@ IF ~~ THEN JA#STH02_2
   IF ~~ THEN DO ~SetGlobal("JA#KNOW_MASKTEMPLE","GLOBAL",1) EscapeArea()~ EXIT
 END
 
-IF ~ReputationGT(LastTalkedToBy,NEUTRAL_UPPER) RandomNum(3,1)~ THEN JA#STH02_3
+IF ~ReputationGT(LastTalkedToBy,15) RandomNum(3,1)~ THEN JA#STH02_3
   SAY @6
   IF ~~ THEN EXIT
 END
 
-IF ~ReputationGT(LastTalkedToBy,NEUTRAL_UPPER) RandomNum(3,2)~ THEN JA#STH02_4
+IF ~ReputationGT(LastTalkedToBy,15) RandomNum(3,2)~ THEN JA#STH02_4
   SAY @7
   IF ~~ THEN EXIT
 END
 
-IF ~ReputationGT(LastTalkedToBy,NEUTRAL_UPPER) RandomNum(3,3)~ THEN JA#STH02_5
+IF ~ReputationGT(LastTalkedToBy,15) RandomNum(3,3)~ THEN JA#STH02_5
   SAY @8
   IF ~~ THEN EXIT
 END


### PR DESCRIPTION
It looks like values from reaction.ids cannot be used for trigger reputation/LT/GT.
*.debug:
`//[trigger list near line 3, column 49 of tb#_compile_eval_buffer/JA#BGT_AdvPack/Shop_of_Silence/ja#sth02.d] PARSE WARNING at line 3 column 1-43 //Near Text: )
//	Type mismatch in "Reputation" argument of [ReputationLT]. 
//	Expecting type "integer". 
//WARNING: cannot verify trigger ~ReputationLT(LastTalkedToBy,FRIENDLY_LOWER)~: Parsing.Parse_error`
